### PR TITLE
update plugin 3P - Progress Programmers Pal 1.7.7 - stability : Good

### DIFF
--- a/plugins/plugins64.xml
+++ b/plugins/plugins64.xml
@@ -10,7 +10,7 @@
 		<homepage>http://jcaillon.github.io/3P/</homepage>
 		<sourceUrl>https://github.com/jcaillon/3P</sourceUrl>
 		<latestUpdate>More infos here :\n2018-01-11 https://github.com/jcaillon/3P/releases/tag/v1.7.7</latestUpdate>
-		<stability>PreRelease</stability>
+		<stability>Good</stability>
 		<minVersion>6.8.0</minVersion>
 		<install>
 			<x64>


### PR DESCRIPTION
Hello,

Thank you for adding the 3P plugin to your list; you previously added the version 1.7.6 which was indeed a beta (preRelease) version, however the latest 1.7.7 version is a stable one, I would like to change this flag in the plugins list.

Also, I would like to only publish stable versions of 3P in the npp plugins list; this is why the x64 was not yet updated and the x32 version was still in 1.7.0 (the last stable release before 1.7.7).

Best regards