### PR TITLE
Add transfer to new server

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -16,3 +16,12 @@ scp $SSH_OPTIONS validate64.json xmldata@nppxmldev.bruderste.in:/data/dev/conten
 scp $SSH_OPTIONS plugins64.zip xmldata@nppxmldev.bruderste.in:/data/dev/content/xml
 
 scp $SSH_OPTIONS plugins64.md5.txt xmldata@nppxmldev.bruderste.in:/data/dev/content/xml
+
+# New server (transferring to both for transition)
+# Transfer the validate first so anyone who get's the new zip will also get the new validation
+scp $SSH_OPTIONS validate64.json xmldata@server2.bruderste.in:/data/dev/content/validate
+
+# Transfer the zip next so we don't break anyone downloading the new md5 and old zip
+scp $SSH_OPTIONS plugins64.zip xmldata@server2.bruderste.in:/data/dev/content/xml
+
+scp $SSH_OPTIONS plugins64.md5.txt xmldata@server2.bruderste.in:/data/dev/content/xml


### PR DESCRIPTION
Temporarily transfer the files to the new server in addition to the "official" one.

We'll take this out when we switch the cloudflare over to the new server