### PR TITLE
Update for CS-Script plugin.

### DIFF
--- a/plugins/plugins64.xml
+++ b/plugins/plugins64.xml
@@ -183,7 +183,7 @@
 		</install>
 	</plugin>
 	<plugin name="CS-Script (C# intellisense)">
-		<x64Version>1.7.8.0</x64Version>
+		<x64Version>1.7.9.0</x64Version>
 		<aliases>
 			<alias name="CS-Script"/>
 		</aliases>
@@ -191,12 +191,12 @@
 		<author>Oleg Shilo</author>
 		<homepage>https://github.com/oleg-shilo/cs-script.npp/blob/master/README.md</homepage>
 		<sourceUrl>https://github.com/oleg-shilo/cs-script.npp/</sourceUrl>
-		<latestUpdate>The first truly portable release. The same plugin binaries are running on both x86 and x64 versions of Notepad++.\nChanges see https://github.com/oleg-shilo/cs-script.npp/releases/tag/v1.7.8.0</latestUpdate>
+		<latestUpdate>The first truly portable release. The same plugin binaries are running on both x86 and x64 versions of Notepad++.\nChanges see https://github.com/oleg-shilo/cs-script.npp/releases/tag/v1.7.9.0</latestUpdate>
 		<minVersion>6.4.5</minVersion>
 		<stability>Good</stability>
 		<install>
 			<x64>
-				<download>https://github.com/oleg-shilo/cs-script.npp/releases/download/v1.7.8.0/CSScriptNpp.1.7.8.0.x64.zip</download>
+				<download>https://github.com/oleg-shilo/cs-script.npp/releases/download/v1.7.9.0/CSScriptNpp.1.7.9.0.x64.zip</download>
 				<copy from="plugins\CSScriptNpp\*.*" to="$PLUGINDIR$\CSScriptNpp" recursive="true"/>
 				<copy from="plugins\CSScriptNpp.x64.dll" to="$PLUGINDIR$\" validate="true"/>
 			</x64>


### PR DESCRIPTION
Release v1.7.9
- Updated CS-Script engine to v3.28.2
- Issue 16: Impossible to hide CS-Script's main panel
- Added option to (config value UseTogglingPanelVisibility) to allow toggling mode for "Show Project Panel" button. Toggling is the default mode.
- Added killing Npp specific instances of VBCSCompiler.exe on editor shutdown.
- Fixed problem with breakpoints correct location being lost upon document formatting.
- Fixed packaging problem with css_dbg.pdb not being included in the distro.